### PR TITLE
Change % to MOD() in pseudocode

### DIFF
--- a/Documentation/Open Location Code API Specification.md
+++ b/Documentation/Open Location Code API Specification.md
@@ -54,7 +54,7 @@ Implementations MUST follow these REQUIREMENTS for all public methods:
 * Latitude inputs MUST treat a latitude greater than 90° N as if it were the North Pole (i.e. at 90° N).
 * Latitude inputs MUST treat a latitude lower than 90° S as if it were the South Pole (i.e. at 90° S).
 * Longitude inputs MUST treat values outside the range from (including) 180° W to (excluding) 180° E as if they were the equivalent longitude in this range.
-* Longitude inputs MUST NOT cause runtime performance linearly dependent on the longitude. E.g. use `LONGITUDE % 360`, not `WHILE (LONGITUDE > 180) LONGITUDE -= 360`.
+* Longitude inputs MUST NOT cause runtime performance linearly dependent on the longitude. E.g. use `MOD(LONGITUDE,360)`, not `WHILE (LONGITUDE > 180) LONGITUDE -= 360`.
 
 ## OPTIONAL notes for all public methods
 


### PR DESCRIPTION
In some languages (Java is one example), % is not the modulo operator but the remainder operator. The difference being that using the remainder operator on a negative input leads to a negative result, something we want to avoid in the exact calculation that is referenced here (we want LONGITUDE to be in range 0..360, not -360..360). As the example is just pseudocode anyway, it's best to avoid this ambiguity by using the more explicit 'MOD()', to avoid faulty implementations down the line.